### PR TITLE
configure.ac: Fix typo causing configure fail

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,4 +35,3 @@ AC_CONFIG_FILES([
   src/Makefile
 ])
 AC_OUTPUT
-~


### PR DESCRIPTION
./configure: line 6072: /home/***: Is a directory

Signed-off-by: Ondrej Pik <ondrej@amarulasolutions.com>